### PR TITLE
Emit start event to get file-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ var download = wget.download(src, output, options);
 download.on('error', function(err) {
     console.log(err);
 });
+download.on('start', function(fileSize) {
+    console.log(fileSize);
+});
 download.on('end', function(output) {
     console.log(output);
 });

--- a/lib/wget.js
+++ b/lib/wget.js
@@ -80,6 +80,10 @@ function download(src, output, options, _parentEvent, redirects) {
             } else {
                 res.pipe(writeStream);
             }
+
+            //emit a start event so the user knows the file-size he's gonna receive
+            downloader.emit('start', fileSize);
+
             // Data handlers
             res.on('data', function(chunk) {
                 downloadedSize += chunk.length;

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,9 @@ var download = wget.download('https://www.npmjs.com/static/images/npm-logo.svg',
 download.on('error', function(err) {
     console.log(err);
 });
+download.on('start', function(fileSize) {
+    console.log(fileSize);
+});
 download.on('end', function(output) {
     console.log(output);
     process.exit();


### PR DESCRIPTION
When starting the download it would be nice to know how big the downloaded file is going to be.
This code emits a "start" event containing the file-size so the user can do stuff like display a progress bar when downloading a file.
