### PR TITLE
Handles redirects to relative path

### DIFF
--- a/lib/wget.js
+++ b/lib/wget.js
@@ -50,11 +50,17 @@ function download(src, output, options, _parentEvent, redirects) {
 
         // Handle 302 redirects
         if(res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307) {
+            
+            var new_location=res.headers.location;
+            if(res.headers.location.indexOf('/')===0) {
+                new_location = srcUrl.protocol+'://'+srcUrl.hostname+(srcUrl.port? ':'+srcUrl.port:'')+res.headers.location;
+            }
+           
             redirects++;
             if(redirects >= 10) {
                 downloader.emit('error', 'Infinite redirect loop detected');
             }
-            download(res.headers.location, output, options, downloader, redirects);
+            download(new_location, output, options, downloader, redirects);
         }
 
         if (res.statusCode === 200) {

--- a/lib/wget.js
+++ b/lib/wget.js
@@ -34,6 +34,10 @@ function download(src, output, options, _parentEvent, redirects) {
         };
     }
     srcUrl = url.parse(src);
+    if(!srcUrl.protocol) {
+        downloader.emit('error', 'Cannot parse url protocol for '+src);
+        return;
+    }
     srcUrl.protocol = cleanProtocol(srcUrl.protocol);
 
     req = request({


### PR DESCRIPTION
@bearjaws 

If url redirects to a relative url e.g. `/another_path` parse the url with previous protocol, host and port

Take, for example:

`http://i.dell.com/resize.aspx/dell-u2417h-monitor-hero/295` 

it redirects to

`/images/global/products/root/dell-u2417h-monitor-hero.jpg`

In the next loop, that url won't be parsed, resulting in an error (protocol is null, which you can't trim  on `cleanProtocol`).

So, to handle those cases, I added the protocol, host and optionally port to the redirect url:

```js
var new_location=res.headers.location;
if(res.headers.location.indexOf('/')===0) {
   new_location = srcUrl.protocol + '://' + srcUrl.hostname+(srcUrl.port? ':'+srcUrl.port:'') + res.headers.location;
}
redirects++;
if(redirects >= 10) {
     downloader.emit('error', 'Infinite redirect loop detected');
}
download(new_location, output, options, downloader, redirects);
```

There is an edge case in which the redirect url doesn't start with a slash, but in that case I'm not sure what should be the final URL.

