### PR TITLE
fix: Bumps minimist to `1.2.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wget-improved",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wget-improved",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "minimist": "1.2.5",
@@ -18,7 +18,7 @@
             "devDependencies": {
                 "chai": "4.0.2",
                 "express": "4.16.3",
-                "mocha": "^9.2.1",
+                "mocha": "9.2.1",
                 "request": "2.88.0"
             },
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
-                "minimist": "1.2.5",
+                "minimist": "1.2.6",
                 "tunnel": "0.0.6"
             },
             "bin": {
@@ -1239,9 +1239,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "node_modules/mocha": {
             "version": "9.2.1",
@@ -2973,9 +2973,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "mocha": {
             "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "typings": "index.d.ts",
     "dependencies": {
-        "minimist": "1.2.5",
+        "minimist": "1.2.6",
         "tunnel": "0.0.6"
     },
     "engines": {


### PR DESCRIPTION
* Fixes GHSA-xvch-5gv4-984h