### PR TITLE
improve CLI progress percentage display

### DIFF
--- a/bin/nwget
+++ b/bin/nwget
@@ -12,6 +12,7 @@ nwget https://raw.github.com/Fyrd/caniuse/master/data.json -O /tmp/data.json
 
 var wget = require('../lib/wget');
 var path = require('path');
+var readline = require('readline');
 
 var args = require('minimist')(process.argv);
 var url = args._[2]
@@ -32,11 +33,18 @@ if (!output) return console.error('The second argument must be a file path for t
 var download = wget.download(url, path.resolve(output));
 
 download.on('error', function(err) {
+    process.stdout.write('\n');
     console.error(err);
 });
 download.on('end', function(output) {
+    readline.cursorTo(process.stdout, 0);
     console.log(output);
 });
 download.on('progress', function(progress) {
-    console.log(progress);
+    printProgressPercent(progress);
 });
+
+function printProgressPercent(progress) {
+    readline.cursorTo(process.stdout, 0);
+    process.stdout.write('Downloading... ' + Math.round(progress * 100) + '%');
+}


### PR DESCRIPTION
Updates the CLI usage to display an updating progress percentage, rather than printing several lines to the console while downloading files.

Before:
![image](https://user-images.githubusercontent.com/25287325/161629074-73003d13-aa34-4998-b0b6-fbba1546ecdf.png)

After:
(while downloading)
![image](https://user-images.githubusercontent.com/25287325/161629131-ed41f488-622f-4ce3-96d1-87443fb5b589.png)
(on completion)
![image](https://user-images.githubusercontent.com/25287325/161629158-baae1d42-278f-4889-b1c7-6ab80c979943.png)
